### PR TITLE
Add support to "name" attribute in network

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -279,6 +279,7 @@
         "type": ["object", "null"],
         "properties": {
           "driver": {"type": "string"},
+          "name":{"type":"string"},
           "driver_opts": {
             "type": "object",
             "patternProperties": {


### PR DESCRIPTION
The actual configuration did not support the attribute "name" that is defined in the docker API documentation.